### PR TITLE
replace magic values with `num_samples` variable (solves an undef variable error, too)

### DIFF
--- a/examples/code_gen_benchmark.jl
+++ b/examples/code_gen_benchmark.jl
@@ -16,6 +16,9 @@ const PT = PromptingTools
 # ## Run for a single test case
 device = "Apple-MacBook-Pro-M1" # "Apple-MacBook-Pro-M1" or "NVIDIA-GTX-1080Ti", broadly "manufacturer-model"
 
+# How many samples to generate for each model/prompt combination
+num_samples = 10
+
 # Select models to run
 #
 # Paid Models:
@@ -62,7 +65,7 @@ fn_definitions = find_definitions("code_generation/")
 evals = run_benchmark(; fn_definitions, models = model_options,
     prompt_labels = prompt_options,
     experiment = "", auto_save = true, verbose = true, device,
-    num_samples = 10, schema_lookup, http_kwargs = (; readtimeout = 150));
+    num_samples = num_samples, schema_lookup, http_kwargs = (; readtimeout = 150));
 # Note: On Mac M1 with Ollama, you want to set api_kwargs=(; options=(; num_gpu=99)) for Ollama to have normal performance
 
 # Voila! You can now find the results in the `temp/` folder or in the vector `evals`!
@@ -176,7 +179,7 @@ df_missing = @chain df begin
         :count = $nrow
     end
     leftjoin(df_all, _, on = [:model, :prompt_label, :name], validate = (true, true))
-    @rtransform :count_missing = 10 - coalesce(:count, 0)
+    @rtransform :count_missing = num_samples - coalesce(:count, 0)
     @rsubset :count_missing > 0
     @orderby -:count_missing
 end

--- a/experiments/yi-quantization-effects-zh/yi_quant_benchmark_zh.jl
+++ b/experiments/yi-quantization-effects-zh/yi_quant_benchmark_zh.jl
@@ -15,6 +15,9 @@ PT.TEMPLATE_STORE[:JuliaExpertAskZH] = template
 device = "NVIDIA-RTX-4090-4x" # "Apple-MacBook-Pro-M1" or "NVIDIA-GTX-1080Ti", broadly "manufacturer-model"
 # export CUDA_VISIBLE_DEVICES=0
 
+# How many samples to generate for each model/prompt combination
+num_samples = 10
+
 # Select models to run
 model_options = [
     # "yi:34b-chat-fp16",
@@ -52,7 +55,7 @@ evals = run_benchmark(; fn_definitions,
     auto_save = true, verbose = true,
     device,
     save_dir = "yi-quantization-effects-zh",
-    num_samples = 10, schema_lookup, http_kwargs = (; readtimeout = 200),
+    num_samples = num_samples, schema_lookup, http_kwargs = (; readtimeout = 200),
     api_kwargs = (; options = (; num_gpu = 99)));
 
 @assert false "Stop here"
@@ -79,7 +82,7 @@ df_missing = @chain df begin
         :count = $nrow
     end
     leftjoin(df_all, _, on = [:model, :prompt_label, :name], validate = (true, true))
-    @rtransform :count_missing = 10 - coalesce(:count, 0)
+    @rtransform :count_missing = num_samples - coalesce(:count, 0)
     @rsubset :count_missing > 0
     @orderby -:count_missing
 end

--- a/experiments/yi-quantization-effects/yi_quant_benchmark.jl
+++ b/experiments/yi-quantization-effects/yi_quant_benchmark.jl
@@ -11,6 +11,9 @@ const PT = PromptingTools
 device = "NVIDIA-RTX-4090" # "Apple-MacBook-Pro-M1" or "NVIDIA-GTX-1080Ti", broadly "manufacturer-model"
 # export CUDA_VISIBLE_DEVICES=0
 
+# How many samples to generate for each model/prompt combination
+num_samples = 10
+
 # Select models to run
 model_options = [
     "yi:34b-chat-fp16",
@@ -54,7 +57,7 @@ evals = run_benchmark(; fn_definitions,
     auto_save = true, verbose = true,
     device,
     save_dir = "yi-quantization-effects",
-    num_samples = 10, schema_lookup, http_kwargs = (; readtimeout = 200),
+    num_samples = num_samples, schema_lookup, http_kwargs = (; readtimeout = 200),
     api_kwargs = (; options = (; num_gpu = 99)));
 
 # evals = run_benchmark(; fn_definitions,
@@ -64,7 +67,7 @@ evals = run_benchmark(; fn_definitions,
 #     auto_save = true, verbose = true,
 #     device,
 #     save_dir = "yi-quantization-effects",
-#     num_samples = 10, schema_lookup, http_kwargs = (; readtimeout = 1000),
+#     num_samples = num_samples, schema_lookup, http_kwargs = (; readtimeout = 1000),
 #     api_kwargs = (; options = (; num_gpu = 99, temperature = 0.3)));
 
 evals = run_benchmark(; fn_definitions,
@@ -74,7 +77,7 @@ evals = run_benchmark(; fn_definitions,
     auto_save = true, verbose = true,
     device,
     save_dir = "magicoder-quantization-effects",
-    num_samples = 10, schema_lookup, http_kwargs = (; readtimeout = 100),
+    num_samples = num_samples, schema_lookup, http_kwargs = (; readtimeout = 100),
     api_kwargs = (; options = (; num_gpu = 99, temperature = 0.5)));
 
 # ## Find missing samples
@@ -99,7 +102,7 @@ df_missing = @chain df begin
         :count = $nrow
     end
     leftjoin(df_all, _, on = [:model, :prompt_label, :name], validate = (true, true))
-    @rtransform :count_missing = 10 - coalesce(:count, 0)
+    @rtransform :count_missing = num_samples - coalesce(:count, 0)
     @rsubset :count_missing > 0
     @orderby -:count_missing
 end


### PR DESCRIPTION
`num_samples` is used multiple times in these scripts. In one place, we use a variable, in another function call, we directly pass a value. There is also an attempt to use `num_samples` variable before defining it. Possible byproduct of a notebook -> script conversion.