### PR TITLE
Fix string inclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ### Fixed
 
+## [0.4.0]
+
+### Fixed
+- Fixed the bug that caused the `include_string` to fail when the code contains a lot of double quotes. It negatively impacted test cases like `q_and_a_extractor` and `extract_julia_code`. This potentially changes some scores, so versioning up.
+
 ## [0.3.0]
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaLLMLeaderboard"
 uuid = "d2e0caaf-b708-450d-8925-7705cdc6ef9e"
 authors = ["J S <49557684+svilupp@users.noreply.github.com>"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 AlgebraOfGraphics = "cbdf2221-f076-402e-a563-3d30da359d67"

--- a/examples/debugging_results.jl
+++ b/examples/debugging_results.jl
@@ -1,21 +1,50 @@
 # # Example how to inspect a certain run
 
 ## Imports
+using PromptingTools
+const PT = PromptingTools
 using JuliaLLMLeaderboard
+using JuliaLLMLeaderboard: load_conversation_from_eval, run_code_main,
+                           run_code_blocks_additive
 using DataFramesMeta
 
 # Load everything
-df = load_evals("code_generation"; max_history=1)
+df = load_evals("code_generation"; max_history = 0)
+# df = load_evals("debug"; max_history = 0)
 
 # Inspect some result
-row = @chain df begin
-    @rsubset :prompt_label == "InJulia" :name == "event_scheduler" :model == "mistral-small"
-end
+# row = @chain df begin
+#     @rsubset :prompt_label=="InJulia" :name=="event_scheduler" :model=="mistral-small"
+# end
+
+# select which row to inspect
+row_idx = 2
 
 # take the evaluation filename and use it to load up the conversation
-conv = row.filename[end] |> load_conversation_from_eval
+conv = df.filename[row_idx] |> load_conversation_from_eval
 edit(conv) # Opens a preview in VSCode, alternatively use `preview(conv)`
 
 # Check out the code parsing results and errors
-cb = AICode(last(conv); skip_unsafe=true)
+cb = AICode(last(conv); skip_unsafe = true)
 cb.error
+
+# load the definition
+definition = load_definition(joinpath(
+    "code_generation", "utility_functions", df.name[row_idx], "definition.toml"))["code_generation"]
+
+## Execute the function definition
+cb, debugs = run_code_main(last(conv); return_debug = true)
+
+## Execute the examples
+cnt, debugs = run_code_blocks_additive(
+    cb, definition["examples"]; return_debug = true, verbose = true)
+
+## Execute the unit tests
+cnt, debugs = run_code_blocks_additive(
+    cb, definition["unit_tests"]; return_debug = true, verbose = true)
+
+## Run evaluation 1shot
+evaluate_1shot(;
+    conversation = conv, fn_definition = "", definition = definition,
+    auto_save = false, model = "", prompt_label = "", schema = PT.OpenAISchema(),
+    return_debug = true, verbose = true)

--- a/examples/debugging_results.jl
+++ b/examples/debugging_results.jl
@@ -18,7 +18,7 @@ df = load_evals("code_generation"; max_history = 0)
 # end
 
 # select which row to inspect
-row_idx = 2
+row_idx = 1
 
 # take the evaluation filename and use it to load up the conversation
 conv = df.filename[row_idx] |> load_conversation_from_eval

--- a/src/evaluation.jl
+++ b/src/evaluation.jl
@@ -74,7 +74,7 @@ function run_code_main(msg::PT.AIMessage; verbose::Bool = true,
                 unique
         !isempty(lines) && (append!(failing_lines,
             sources[[err for err in lines
-                         if err <= length(sources)]]))
+                     if err <= length(sources)]]))
         verbose &&
             @warn "Main Run Failure:\nError: $(cb.error)\nStdOut: $(cb.stdout)\n\nFailing lines:\n- $(join(failing_lines, "\n- "))"
         return_debug && (push!(debugs,
@@ -119,7 +119,8 @@ run_code_blocks(cb, [code])
 # Output: 1 (= 1 example executed without an error thrown)
 ```
 """
-function run_code_blocks_additive(cb::AICode, code_blocks::AbstractVector{<:AbstractString};
+function run_code_blocks_additive(
+        cb::AICode, code_blocks::AbstractVector{<:AbstractString};
         verbose::Bool = false,
         setup_code::AbstractString = "", teardown_code::AbstractString = "",
         capture_stdout::Bool = true, execution_timeout::Int = 60,
@@ -133,7 +134,8 @@ function run_code_blocks_additive(cb::AICode, code_blocks::AbstractVector{<:Abst
     for (i, code) in enumerate(code_blocks)
         # Prepare the code to evaluate and evaluate it in the same module as the original code
         code_joined = string(setup_code, "\n\n", code, "\n\n", teardown_code)
-        code_include = "include_string(identity, $eval_module,\"\"\"$(escape_string(code_joined,'$'))\"\"\", \"__code_string_eval_additive\")\n"
+        code_escaped = escape_string(code_joined, ['"', '$'])
+        code_include = "include_string(identity, $eval_module,\"\"\"$(code_escaped)\"\"\", \"__code_string_eval_additive\")\n"
         code_expr = Meta.parseall(code_include)
         # We run with timeout to avoid infinite loops
         out = PT.@timeout execution_timeout begin
@@ -150,13 +152,13 @@ function run_code_blocks_additive(cb::AICode, code_blocks::AbstractVector{<:Abst
                     unique
             !isempty(lines) && (append!(failing_lines,
                 sources[[err for err in lines
-                             if err <= length(sources)]]))
+                         if err <= length(sources)]]))
             sources = split(cb.code, '\n')
             lines = PT.extract_stacktrace_lines("__code_string_eval", cb_copy.stdout) |>
                     unique
             !isempty(lines) && (append!(failing_lines,
                 sources[[err for err in lines
-                             if err <= length(sources)]]))
+                         if err <= length(sources)]]))
             verbose &&
                 @warn "Run Failure (i: $i):\nError: $(cb_copy.error)\nStdOut: $(cb_copy.stdout)\n\nFailing lines:\n- $(join(failing_lines, "\n- "))"
             return_debug && (push!(debugs,
@@ -385,7 +387,7 @@ function load_evals(base_dir::AbstractString;
         :version_prompt,
         :parameters,
         :experiment,
-        new_columns...,
+        new_columns...
     ]
 
     df = DataFrame([Dict(c => get(row, c, missing) for c in eval_cols) for row in output])
@@ -404,7 +406,7 @@ function load_evals(base_dir::AbstractString;
     if "parameters" in names(df) && all(!ismissing, df.parameters)
         unique_params = df.parameters .|> keys .|> collect |> Base.Splat(vcat) |> unique
         @rtransform! df $AsTable=Dict(param => get(:parameters, param, missing)
-                                      for param in unique_params)
+        for param in unique_params)
     end
     return df
 end
@@ -463,7 +465,7 @@ function score_eval(parsed,
         parsed,
         executed,
         unit_tests_success_ratio,
-        examples_success_ratio,
+        examples_success_ratio
     ]
         !ismissing(category_score) && (total_score += category_score * points_per_category)
     end


### PR DESCRIPTION
This PR fixes string inclusion for injecting code with several nested quote levels. 

It explicitly escapes the double quote symbol before injecting the raw code string.

It led to failures in test cases with heavy string use - Q&A Extractor and Extract Julia Code.